### PR TITLE
Handling of Mandrill returning result of mail post job as array when …

### DIFF
--- a/src/Services/MandrillService.php
+++ b/src/Services/MandrillService.php
@@ -82,7 +82,9 @@ class MandrillService
          */
         $result = $mandrill->messages->sendTemplate($body);
 
-        if (gettype($result) === 'array') return (object) $result;
+        if (gettype($result) === 'array') {
+            return (object) $result;
+        }
 
         return $result;
     }

--- a/src/Services/MandrillService.php
+++ b/src/Services/MandrillService.php
@@ -82,6 +82,8 @@ class MandrillService
          */
         $result = $mandrill->messages->sendTemplate($body);
 
+        if (gettype($result) === 'array') return (object) $result;
+
         return $result;
     }
 }


### PR DESCRIPTION
## Context

On PTC Hub when I dispatch a mail to onboard a user the response from the Mandrill Service we built is expected to be an object. 

However inside their service if the response has a header identifying it as 

## PR Checklist

- [x] PR branch based to `develop`
- [x] Meaningful PR Name added (This will be in release notes)
- [x] The changes have been added to the dev docs changelog
- [x] Relevant Unit tests have been added
   - [x]  No tests required
- [x] PHP Stan has been run `vendor/bin/phpstan analyse`
- [x] Unit tests have been run and pass `php artisan test`
   - [x]  No need for unit test to be run (very minor changes)
- [x] Meaningful PR Description added (This will be in release notes)
- [x] Link relevant issues
- [x] Add reviewers to PR

## Changes…we are expecting an object