### PR TITLE
Enhancement - Nested permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `core` will be documented in this file.
 
+## Upcoming for release
+
+- Adds new permissions methods to support nested dependencies
+
 ## v0.0.8 - 2022-03-25
 
 ## What's Changed

--- a/database/migrations/create_permission_peer_table.php.stub
+++ b/database/migrations/create_permission_peer_table.php.stub
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('permission_peer', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('peer_id');
+            $table->unsignedBigInteger('permission_id');
+            $table->foreign('peer_id')->references('id')->on('permissions')->onDelete('cascade');
+            $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "core",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Package containing core logic, templates and components used across Salt web apps",
     "scripts": {
         "docs:dev": "vuepress dev docs",

--- a/src/CoreServiceProvider.php
+++ b/src/CoreServiceProvider.php
@@ -45,6 +45,7 @@ class CoreServiceProvider extends PackageServiceProvider
                     'create_roles_table',
                     'create_permission_role_table',
                     'create_permission_user_table',
+                    'create_permission_peer_table',
                     'create_role_user_table',
                     'create_settings_table',
                 ]

--- a/src/Exceptions/PermissionDependencyException.php
+++ b/src/Exceptions/PermissionDependencyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Salt\Core\Exceptions;
+
+use Exception;
+
+class PermissionDependencyException extends Exception {}

--- a/src/Exceptions/PermissionDependencyException.php
+++ b/src/Exceptions/PermissionDependencyException.php
@@ -4,4 +4,6 @@ namespace Salt\Core\Exceptions;
 
 use Exception;
 
-class PermissionDependencyException extends Exception {}
+class PermissionDependencyException extends Exception
+{
+}

--- a/src/Models/PeerPermission.php
+++ b/src/Models/PeerPermission.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Salt\Core\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class PeerPermission extends Pivot
+{
+    protected $table = 'permission_peer';
+}

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -36,8 +36,8 @@ class Permission extends Model
         return $this->belongsToMany(self::class, PeerPermission::class, 'permission_id', 'peer_id')->withTimestamps();
     }
 
-    public function requiresPeers()
+    public function requiresPermissions()
     {
-        return $this->peers()->count() > 0;
+        return $this->dependencies()->count() > 0;
     }
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -25,4 +25,19 @@ class Permission extends Model
     {
         return $this->belongsToMany(Role::class)->withTimestamps();
     }
+
+    public function dependencies()
+    {
+        return $this->belongsToMany(self::class, PeerPermission::class, 'peer_id', 'permission_id')->withTimestamps();
+    }
+
+    public function dependants()
+    {
+        return $this->belongsToMany(self::class, PeerPermission::class, 'permission_id', 'peer_id')->withTimestamps();
+    }
+
+    public function requiresPeers()
+    {
+        return $this->peers()->count() > 0;
+    }
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -31,4 +31,9 @@ class Role extends Model
     {
         return $this->belongsToMany(config('auth.providers.users.model'))->using(UserRole::class);
     }
+
+    public function hasPermission($permission)
+    {
+        return $this->permissions()->where('name', $permission)->exists();
+    }
 }

--- a/src/Models/UserPermission.php
+++ b/src/Models/UserPermission.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Salt\Core\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Salt\Core\Observers\PermissionDependenciesObserver;
+
+class UserPermission extends Pivot
+{
+    protected $table = 'permission_user';
+
+    public static function boot()
+    {
+        parent::boot();
+        UserPermission::observe(PermissionDependenciesObserver::class);
+    }
+}

--- a/src/Observers/PermissionDependenciesObserver.php
+++ b/src/Observers/PermissionDependenciesObserver.php
@@ -9,8 +9,8 @@ use Salt\Core\Services\UserPermissionService;
 class PermissionDependenciesObserver
 {
 
-    public function __construct(UserPermissionService $userPermissionService ){
-        $this->userPermissionService = $userPermissionService;
+    public function __construct(UserPermissionService $user_permission_service ){
+        $this->user_permission_service = $user_permission_service;
     }
 
     /**
@@ -23,6 +23,6 @@ class PermissionDependenciesObserver
      */
     public function creating(UserPermission $user_permission)
     {
-        $this->userPermissionService->verifyDependencies($user_permission);
+        $this->user_permission_service->verifyDependencies($user_permission);
     }
 }

--- a/src/Observers/PermissionDependenciesObserver.php
+++ b/src/Observers/PermissionDependenciesObserver.php
@@ -8,7 +8,6 @@ use Salt\Core\Services\UserPermissionService;
 
 class PermissionDependenciesObserver
 {
-
     public function __construct(UserPermissionService $user_permission_service ){
         $this->user_permission_service = $user_permission_service;
     }

--- a/src/Observers/PermissionDependenciesObserver.php
+++ b/src/Observers/PermissionDependenciesObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Salt\Core\Observers;
+
+use Salt\Core\Models\User;
+use Salt\Core\Models\UserPermission;
+use Salt\Core\Services\UserPermissionService;
+
+class PermissionDependenciesObserver
+{
+
+    public function __construct(UserPermissionService $userPermissionService ){
+        $this->userPermissionService = $userPermissionService;
+    }
+
+    /**
+     * Handle the UserPermission "creating" event.
+     * Throws an error if the user requires more
+     * permissions before adding this one.
+     *
+     * @param  UserPermission  $user_permission
+     * @return void
+     */
+    public function creating(UserPermission $user_permission)
+    {
+        $this->userPermissionService->verifyDependencies($user_permission);
+    }
+}

--- a/src/Observers/PermissionDependenciesObserver.php
+++ b/src/Observers/PermissionDependenciesObserver.php
@@ -8,7 +8,8 @@ use Salt\Core\Services\UserPermissionService;
 
 class PermissionDependenciesObserver
 {
-    public function __construct(UserPermissionService $user_permission_service ){
+    public function __construct(UserPermissionService $user_permission_service)
+    {
         $this->user_permission_service = $user_permission_service;
     }
 

--- a/src/Options/PermissionEnums.php
+++ b/src/Options/PermissionEnums.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Salt\Core\Enums;
+
+/**
+ * If using PHP 8.1+, it may make sense
+ * to use enums as an approach to store
+ * permissions.
+ */
+
+enum UserPermissions: string
+{
+    case VIEW_ADMIN_DASHBOARD = 'view-admin-dashboard';
+    case MANAGE_USERS = 'manage-users';
+
+    public function label(): string
+    {
+        return match ($this) {
+            UserPermissions::VIEW_ADMIN_DASHBOARD => 'View admin dashboard',
+            UserPermissions::MANAGE_USERS => 'Manage users'
+        };
+    }
+
+    public function description(): string
+    {
+        return match ($this) {
+            UserPermissions::VIEW_ADMIN_DASHBOARD => 'Access the administration dashboard',
+            UserPermissions::MANAGE_USERS => 'Manage application users'
+        };
+    }
+
+    public function dependencies(): array
+    {
+        return match ($this) {
+            UserPermissions::VIEW_ADMIN_DASHBOARD => [],
+            UserPermissions::MANAGE_USERS => [
+                UserPermissions::VIEW_ADMIN_DASHBOARD,
+            ],
+        };
+    }
+}

--- a/src/Services/UserPermissionService.php
+++ b/src/Services/UserPermissionService.php
@@ -2,15 +2,15 @@
 
 namespace Salt\Core\Services;
 
-use Salt\Core\Models\Role;
-use Salt\Core\Models\User;
-use Salt\Core\Models\Permission;
-use Salt\Core\Models\UserPermission;
 use Salt\Core\Exceptions\PermissionDependencyException;
+use Salt\Core\Models\Permission;
+use Salt\Core\Models\User;
+use Salt\Core\Models\UserPermission;
 
 class UserPermissionService
 {
-    public static function verifyDependencies( UserPermission $user_permission ){
+    public static function verifyDependencies(UserPermission $user_permission)
+    {
         $permission = Permission::find($user_permission->permission_id);
         $user = User::find($user_permission->user_id);
         $dependencies = $permission->dependencies;

--- a/src/Services/UserPermissionService.php
+++ b/src/Services/UserPermissionService.php
@@ -14,9 +14,9 @@ class UserPermissionService
         $permission = Permission::find($user_permission->permission_id);
         $user = User::find($user_permission->user_id);
         $dependencies = $permission->dependencies;
-        foreach( $dependencies as $perm ){
-            if( !$user->hasPermission($perm) ){
-                throw new PermissionDependencyException('User requires ' . $perm->name . ' permission in order to be granted ' . $permission->name );
+        foreach ($dependencies as $perm) {
+            if (!$user->hasPermission($perm)) {
+                throw new PermissionDependencyException('User requires ' . $perm->name . ' permission in order to be granted ' . $permission->name);
             }
         }
     }

--- a/src/Services/UserPermissionService.php
+++ b/src/Services/UserPermissionService.php
@@ -17,7 +17,6 @@ class UserPermissionService
         foreach( $dependencies as $perm ){
             if( !$user->hasPermission($perm) ){
                 throw new PermissionDependencyException('User requires ' . $perm->name . ' permission in order to be granted ' . $permission->name );
-                return false;
             }
         }
     }

--- a/src/Services/UserPermissionService.php
+++ b/src/Services/UserPermissionService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Salt\Core\Services;
+
+use Salt\Core\Models\Role;
+use Salt\Core\Models\User;
+use Salt\Core\Models\Permission;
+use Salt\Core\Models\UserPermission;
+use Salt\Core\Exceptions\PermissionDependencyException;
+
+class UserPermissionService
+{
+    public static function verifyDependencies( UserPermission $user_permission ){
+        $permission = Permission::find($user_permission->permission_id);
+        $user = User::find($user_permission->user_id);
+        $dependencies = $permission->dependencies;
+        foreach( $dependencies as $perm ){
+            if( !$user->hasPermission($perm) ){
+                throw new PermissionDependencyException('User requires ' . $perm->name . ' permission in order to be granted ' . $permission->name );
+                return false;
+            }
+        }
+    }
+}

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -4,6 +4,7 @@ namespace Salt\Core\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
 use Salt\Core\Models\Permission;
+use Salt\Core\Models\UserPermission;
 
 trait HasPermissions
 {
@@ -20,7 +21,7 @@ trait HasPermissions
 
     public function permissions()
     {
-        return $this->belongsToMany(Permission::class, 'permission_user')->withTimestamps();
+        return $this->belongsToMany(Permission::class, 'permission_user')->withTimestamps()->using(UserPermission::class);
     }
 
     public function hasPermission($permission)

--- a/tests/CurrentUserTest.php
+++ b/tests/CurrentUserTest.php
@@ -2,6 +2,7 @@
 
 use function Pest\Laravel\actingAs;
 use function PHPUnit\Framework\assertEquals;
+
 use Salt\Core\Facades\CurrentUser;
 
 use Salt\Core\Models\Role;

--- a/tests/HasImpersonationTest.php
+++ b/tests/HasImpersonationTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Session;
+
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertFalse;
 
 use function PHPUnit\Framework\assertTrue;
+
 use Salt\Core\Models\Role;
 use Salt\Core\Models\User;
 

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+
+use Salt\Core\Models\Permission;
+use Salt\Core\Models\Role;
+use Salt\Core\Models\User;
+
+beforeEach(function () {
+    $this->testUser = User::factory()->create();
+
+    $permission = Permission::factory()->create(['name' => 'view-admin-dashboard']);
+    $permission2 = Permission::factory()->create(['name' => 'edit-settings']);
+    $permission3 = Permission::factory()->create(['name' => 'manage-users']);
+    $this->role = Role::factory()->create(['name' => 'admin']);
+    $this->role->permissions()->attach($permission2);
+    $this->role->permissions()->attach($permission);
+});
+
+it('can check if role has a specific permission', function () {
+    assertTrue($this->role->hasPermission('view-admin-dashboard'));
+    assertTrue($this->role->hasPermission('edit-settings'));
+    assertFalse($this->role->hasPermission('manage-users'));
+});
+
+it('can get the correct role permissions', function () {
+    assertTrue(count($this->role->permissions) === 2);
+});

--- a/tests/MenuBuilderTest.php
+++ b/tests/MenuBuilderTest.php
@@ -8,6 +8,7 @@ use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertIsArray;
 
 use function PHPUnit\Framework\assertNotEquals;
+
 use Salt\Core\Data\MenuItem;
 use Salt\Core\Data\MenuSectionItem;
 use Salt\Core\Models\MenuBuilder;

--- a/tests/PerPagePaginateTraitTest.php
+++ b/tests/PerPagePaginateTraitTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use function PHPUnit\Framework\assertEquals;
+
 use Salt\Core\Models\User;
 
 beforeEach(function () {

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use Illuminate\Database\QueryException;
+
 use function Pest\Faker\faker;
 use function PHPUnit\Framework\assertEquals;
 
 use function PHPUnit\Framework\assertTrue;
+
 use Salt\Core\Models\Permission;
 
 use Salt\Core\Models\Role;

--- a/tests/PermissionsPeersTest.php
+++ b/tests/PermissionsPeersTest.php
@@ -1,13 +1,10 @@
 <?php
 
-use function PHPUnit\Framework\assertFalse;
-use function PHPUnit\Framework\assertTrue;
 use function PHPUnit\Framework\assertEquals;
 
-use Salt\Core\Models\Permission;
-use Salt\Core\Models\Role;
-use Salt\Core\Models\User;
 use Salt\Core\Exceptions\PermissionDependencyException;
+use Salt\Core\Models\Permission;
+use Salt\Core\Models\User;
 
 beforeEach(function () {
     $this->test_user = User::factory()->create();

--- a/tests/PermissionsPeersTest.php
+++ b/tests/PermissionsPeersTest.php
@@ -10,7 +10,7 @@ use Salt\Core\Models\User;
 use Salt\Core\Exceptions\PermissionDependencyException;
 
 beforeEach(function () {
-    $this->testUser = User::factory()->create();
+    $this->test_user = User::factory()->create();
 
     $this->perm1 = Permission::factory()->create(['name' => 'view-admin-dashboard']);
     $this->perm2 = Permission::factory()->create(['name' => 'edit-settings']);
@@ -21,14 +21,28 @@ beforeEach(function () {
 });
 
 it('a permission can have 1 or more dependencies', function () {
-    assertEquals(count($this->perm2->dependencies), 1);
-    assertEquals(count($this->perm3->dependencies), 1);
+    assertEquals(count($this->perm2->dependencies()->get()), 1);
+    assertEquals(count($this->perm3->dependencies()->get()), 1);
 });
 
 it('a permission can have 1 or more dependants', function () {
-    assertEquals(count($this->perm1->dependants), 2);
+    assertEquals(count($this->perm1->dependants()->get()), 2);
 });
 
 it('cannot allow a permission to be assigned to the user without the prerequisites', function () {
-    $this->testUser->permissions()->attach($this->perm3);
+    $this->test_user->permissions()->attach($this->perm3);
 })->throws(PermissionDependencyException::class, 'User requires view-admin-dashboard permission in order to be granted manage-users');
+
+it('allows the dependency permission to be deleted and removes dependent relationship', function () {
+    $this->perm1->delete();
+    assertEquals(count($this->perm2->dependencies()->get()), 0);
+    assertEquals(count($this->perm3->dependencies()->get()), 0);
+});
+
+it('allows the dependent permission to be deleted and removes dependent relationship', function () {
+    $this->perm3->delete();
+    assertEquals(count($this->perm1->dependants()->get()), 1);
+
+    $this->perm2->delete();
+    assertEquals(count($this->perm1->dependants()->get()), 0);
+});

--- a/tests/PermissionsPeersTest.php
+++ b/tests/PermissionsPeersTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+use function PHPUnit\Framework\assertEquals;
+
+use Salt\Core\Models\Permission;
+use Salt\Core\Models\Role;
+use Salt\Core\Models\User;
+use Salt\Core\Exceptions\PermissionDependencyException;
+
+beforeEach(function () {
+    $this->testUser = User::factory()->create();
+
+    $this->perm1 = Permission::factory()->create(['name' => 'view-admin-dashboard']);
+    $this->perm2 = Permission::factory()->create(['name' => 'edit-settings']);
+    $this->perm3 = Permission::factory()->create(['name' => 'manage-users']);
+
+    $this->perm2->dependencies()->attach($this->perm1);
+    $this->perm3->dependencies()->attach($this->perm1);
+});
+
+it('a permission can have 1 or more dependencies', function () {
+    assertEquals(count($this->perm2->dependencies), 1);
+    assertEquals(count($this->perm3->dependencies), 1);
+});
+
+it('a permission can have 1 or more dependants', function () {
+    assertEquals(count($this->perm1->dependants), 2);
+});
+
+it('cannot allow a permission to be assigned to the user without the prerequisites', function () {
+    $this->testUser->permissions()->attach($this->perm3);
+})->throws(PermissionDependencyException::class, 'User requires view-admin-dashboard permission in order to be granted manage-users');

--- a/tests/PermissionsPeersTest.php
+++ b/tests/PermissionsPeersTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
 
 use Salt\Core\Exceptions\PermissionDependencyException;
 use Salt\Core\Models\Permission;
@@ -42,4 +44,9 @@ it('allows the dependent permission to be deleted and removes dependent relation
 
     $this->perm2->delete();
     assertEquals(count($this->perm1->dependants()->get()), 0);
+});
+
+it('can check whether peers are required', function () {
+    assertFalse($this->perm1->requiresPermissions());
+    assertTrue($this->perm2->requiresPermissions());
 });

--- a/tests/SettingTest.php
+++ b/tests/SettingTest.php
@@ -7,6 +7,7 @@ use function PHPUnit\Framework\assertCount;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertTrue;
+
 use Salt\Core\Models\Setting;
 
 beforeEach(function () {

--- a/tests/TableDataCollectionTest.php
+++ b/tests/TableDataCollectionTest.php
@@ -3,9 +3,11 @@
 use Illuminate\Foundation\Http\FormRequest;
 
 use Illuminate\Pagination\LengthAwarePaginator;
+
 use function PHPUnit\Framework\assertEquals;
 
 use function PHPUnit\Framework\assertTrue;
+
 use Salt\Core\Collections\TableDataCollection;
 use Salt\Core\Models\User;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,6 +48,9 @@ class TestCase extends Orchestra
         $permissionUserTable = include  __DIR__ . '/../database/migrations/create_permission_user_table.php.stub';
         $permissionUserTable->up();
 
+        $permissionPeerTable = include  __DIR__ . '/../database/migrations/create_permission_peer_table.php.stub';
+        $permissionPeerTable->up();
+
         $settingsTable = include  __DIR__ . '/../database/migrations/create_settings_table.php.stub';
         $settingsTable->up();
 


### PR DESCRIPTION
## Context

Permissions often require some degree of nesting, for example, an admin should not be able to edit a specific user if they can't see all users, and this might be broken up into two permissions (view-users, edit-user).

To be more testable, this should sit as close to the DB / model layer as possible. The solution provided is to use an observer to reject permissions saved to a user if they don't have the prerequisite permission. The user experience should be a little different as in the front end, the administrator should be required to grant them the required permissions first. 

## PR Checklist

- [x] PR branch based to `main`
- [x] Meaningful PR Name added (This will be in release notes)
- [x] The changes have been added to the dev docs changelog
- [x] Relevant Unit tests have been added
   - [ ]  No tests required
- [ ] PHP Stan has been run `vendor/bin/phpstan analyse`
- [x] Unit tests have been run and pass `php artisan test`
   - [ ]  No need for unit test to be run (very minor changes)
- [x] Meaningful PR Description added (This will be in release notes)
- [ ] Link relevant issues
- [x] Add reviewers to PR

## Changes
- Takes over control of pivot model UserPermission in order to add an observer
- Adds a PeerPermission pivot model in order to have dependencies and dependants available on Permission model
- Adds tests to demonstrate attaching permissions and exception thrown
- Adds support for `hasPermission` to Role model
- Adds enum examples
- Updates docs